### PR TITLE
fix: wikilinks regex with "-"

### DIFF
--- a/core/models/link.js
+++ b/core/models/link.js
@@ -48,7 +48,7 @@ module.exports = class Link {
 
   /** @exemple `"[[a:20210424214230|link text]]"` */
   static regexWikilink = new RegExp(
-    /\[\[((?<type>[\w ]+):)?(?<id>[\w ]+)(\|(?<text>.+?))?\]\]/,
+    /\[\[((?<type>[\w ]+):)?(?<id>[\w\s\-_]+)(\|(?<text>.+?))?\]\]/,
     'g',
   );
 

--- a/core/test/link.js
+++ b/core/test/link.js
@@ -9,7 +9,7 @@ describe('Link', () => {
     const ids = [
       '20210613084440',
       'simpleString',
-      'string with white spaces',
+      'string with white-spaces',
       '20210619085713',
       '20210613173849',
     ];


### PR DESCRIPTION
Now parse `See [[Evergreen notes should be concept-oriented]].`