### PR TITLE
feat: remove ctime timeline

### DIFF
--- a/core/models/config.js
+++ b/core/models/config.js
@@ -55,7 +55,6 @@ module.exports = class Config {
     attraction_vertical: 0,
     attraction_horizontal: 0,
     views: {},
-    chronological_record_meta: 'created',
     record_metas: [],
     generate_id: 'always',
     title: '',
@@ -540,16 +539,6 @@ module.exports = class Config {
 
     const views = Config.isValidViews(this.opts['views']) ? null : 'views';
 
-    const chronological_record_meta = new Set([
-      'lastOpen',
-      'lastEdit',
-      'created',
-      'timestamp',
-      'manual',
-    ]).has(this.opts.chronological_record_meta)
-      ? null
-      : 'chronological_record_meta';
-
     const generate_id = new Set(['always', 'never', 'ask']).has(this.opts.generate_id)
       ? null
       : 'generate_id';
@@ -572,7 +561,6 @@ module.exports = class Config {
       link_types,
       lang,
       views,
-      chronological_record_meta,
       node_size_method,
       record_filters,
       generate_id,

--- a/core/models/cosmoscope.js
+++ b/core/models/cosmoscope.js
@@ -11,7 +11,6 @@
  * @property {string} name
  * @property {string} content
  * @property {FileMetas} metas
- * @property {FileDates} dates
  */
 
 /**
@@ -25,15 +24,6 @@
  * @property {string | undefined} thumbnail
  * @property {number} begin
  * @property {number} end
- */
-
-/**
- * @typedef FileDates
- * @type {object}
- * @property {Date} lastOpen
- * @property {Date} lastEdit
- * @property {Date} created
- * @property {Date} timestamp
  */
 
 /**
@@ -128,15 +118,6 @@ module.exports = class Cosmoscope extends Graph {
 
         /** @type {File} */
         const file = Cosmoscope.getDataFromYamlFrontMatter(fileContain, filePath);
-
-        const { ctime } = fs.statSync(filePath);
-
-        file.dates = { created: ctime };
-
-        const idAsNumber = Number(file.metas.id);
-        if (isNaN(idAsNumber) === false && file.metas.id.length === 14) {
-          file.dates.timestamp = Record.getDateFromId(idAsNumber);
-        }
 
         return file;
       })
@@ -312,7 +293,7 @@ module.exports = class Cosmoscope extends Graph {
       let { id, title, types, tags, thumbnail, references, ...rest } = file.metas;
       id = id || file.metas['title'].toLowerCase();
 
-      let { begin: manualBegin, end: manualEnd, ...metas } = rest;
+      let { begin, end, ...metas } = rest;
       const { linksReferences, backlinksReferences } = Link.getReferencesFromLinks(
         id,
         links,
@@ -322,19 +303,6 @@ module.exports = class Cosmoscope extends Graph {
         ...Bibliography.getBibliographicRecordsFromText(file.content),
         ...Bibliography.getBibliographicRecordsFromList(references),
       ];
-
-      let begin, end;
-
-      switch (opts.chronological_record_meta) {
-        case 'created':
-        case 'timestamp':
-          begin = file.dates[opts.chronological_record_meta];
-          break;
-        case 'manual':
-          begin = manualBegin;
-          end = manualEnd;
-          break;
-      }
 
       return new Record(
         id,

--- a/core/utils/fake.js
+++ b/core/utils/fake.js
@@ -87,16 +87,6 @@ function getRecords(nb, opts = config.opts) {
       name: faker.system.commonFileName('md'),
       lastEditDate: faker.date.past(),
       content,
-      dates: {
-        timestamp: faker.datatype.datetime({
-          min: new Date('1990-01-01'),
-          max: new Date('2000-01-01'),
-        }),
-        created: faker.datatype.datetime({
-          min: new Date('2000-01-01'),
-          max: new Date('2010-01-01'),
-        }),
-      },
       metas: {
         id: fileId,
         title: faker.name.jobTitle(),


### PR DESCRIPTION
Now only use `begin` and `end` from YAML front matter