### PR TITLE
Throw new error when parsing YAML

### DIFF
--- a/core/models/cosmoscope.js
+++ b/core/models/cosmoscope.js
@@ -139,12 +139,12 @@ module.exports = class Cosmoscope extends Graph {
    */
 
   static getDataFromYamlFrontMatter(fileContain, filePath) {
-    let fm ;
+    let fm;
     try {
       fm = readYmlFm(fileContain, { schema: 'failsafe' });
-    } catch(e) {
-      console.error(filePath + " could not have its frontmatter parsed.")
-      throw new SyntaxError("YAML parse error on " + filePath);
+    } catch (e) {
+      console.error(filePath + ' could not have its frontmatter parsed.');
+      throw new SyntaxError('YAML parse error on ' + filePath);
     }
 
     /** @type {File} */

--- a/core/models/cosmoscope.js
+++ b/core/models/cosmoscope.js
@@ -139,7 +139,13 @@ module.exports = class Cosmoscope extends Graph {
    */
 
   static getDataFromYamlFrontMatter(fileContain, filePath) {
-    const { head: metas, content } = readYmlFm(fileContain, { schema: 'failsafe' });
+    let fm ;
+    try {
+      fm = readYmlFm(fileContain, { schema: 'failsafe' });
+    } catch(e) {
+      console.error(filePath + " could not have its frontmatter parsed.")
+      throw new SyntaxError("YAML parse error on " + filePath);
+    }
 
     /** @type {File} */
     const file = {


### PR DESCRIPTION
I started using Cosma with my Zettlr setup, and it was a bit frustrating not to know which file was the problem when there was a parsing error on the YAML frontmatter. Now it is more clear. I made it so it still stops the execution, but maybe it should be just a warning.