### PR TITLE
Flake for declarative installation through nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1783224372,
+        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,48 @@
+{
+  description = "Cosma — a document graph visualization tool";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system nixpkgs.legacyPackages.${system});
+    in
+    {
+      packages = forAllSystems (
+        system: pkgs: {
+          default = pkgs.buildNpmPackage {
+            pname = "cosma";
+            version = "2.6.1";
+            src = ./.;
+            nodejs = pkgs.nodejs_22;
+
+            # Use package-lock.json instead of flake.lock for dependency locking.
+            npmDeps = pkgs.importNpmLock { npmRoot = ./.; };
+            npmConfigHook = pkgs.importNpmLock.npmConfigHook;
+
+            # Skip install lifecycle scripts during `npm ci`.
+            npmFlags = [ "--ignore-scripts" ];
+
+            npmBuildScript = "prepare";
+
+            meta = {
+              description = "Document graph visualization tool";
+              homepage = "https://cosma.arthurperret.fr/";
+              license = with pkgs.lib.licenses; [
+                gpl3Plus
+                cecill21
+              ];
+              mainProgram = "cosma";
+            };
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
By placing this flake.nix and flake.lock in the root of your repo, [nix](https://github.com/nixos/nix) users can run it through
```sh
nix run github:graphlab-fr/cosma --override-input nixpkgs github:nixpkgs/nixos-26.05 -- config
```
or install it inside their `flake.nix` files.

**Maintenance?**  
If your build process changes, the `flake.nix` might break. `nix` is good at pinning to older versions though, so users won't suddenly stand in the cold. Me or any LLM will be able to restore the flake to function.

**Security?**  
`flake.lock` will gradually age. Nix users would be advised to override the nixpkgs input, which isn't an uncommon practice. But by default, if some big security gap is found in node then patches won't propagate to users. I _think_ this is a non-issue given the nature of cosma, but I don't mind setting a bi-yearly alarm so I update the flake.lock here (all it'd involve is running `nix flake update` and committing the new flake.lock)

Of course, if you'd rather not have tools here that you don't use yourself then I understand that very well.